### PR TITLE
Fix wrong names in GraphQL API

### DIFF
--- a/src/resolvers/customFieldResolvers.ts
+++ b/src/resolvers/customFieldResolvers.ts
@@ -19,7 +19,7 @@ type Context = {
 @Resolver(of => Token)
 export class CustomTokenFieldsResolver {
   @FieldResolver(type => Number, { nullable: true })
-  async takerPaysPriceInUsd(
+  async priceInUsd(
     @Root() token: Token,
     @Ctx() { prisma }: Context,
   ): Promise<number | undefined> {

--- a/src/resolvers/customFieldResolvers.ts
+++ b/src/resolvers/customFieldResolvers.ts
@@ -105,7 +105,7 @@ export class CustomOrderFieldsResolver {
   }
 
   @FieldResolver(type => Number, { nullable: true })
-  async takerPaysPriceInUsd(
+  async takerPaidPriceInUsd(
     @Root() order: Order,
     @Ctx() ctx: Context,
   ): Promise<number | undefined> {
@@ -117,7 +117,7 @@ export class CustomOrderFieldsResolver {
   }
 
   @FieldResolver(type => Number, { nullable: true })
-  async makerPaysPriceInUsd(
+  async makerPaidPriceInUsd(
     @Root() order: Order,
     @Ctx() ctx: Context,
   ): Promise<number | undefined> {


### PR DESCRIPTION
I made a few naming mistakes in an earlier refac of the GraphQL code - this PR fixes these:

- Rename Token.takerPaysPriceInUsd to Token.priceInUsd in GraphQL API
- Rename Order.[tm]akerPaysPriceInUsd to `Order.[tm]akerPaidPriceInUsd` in GraphQL API